### PR TITLE
Revert changes in `site` and update testcases

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ The same `Parameters` can also be defined by `Config3.orElse(Config2).orElse(Con
 ### Environment Reference
 Each query contains the entire environment of where the query originates. This is pass to the lookup table of each `Config` by `(site, here, up)` arguments.
 
-- `site` dynamically refers to the entire table
 - `here` dynamically refers to the current row of the table
 - `up` dynamically refers to the rows appearing up than the current row
+- `site` dynamically refers to the entire table. When it gets called by `here` or `up` queries, it still refers to the **entire** table instead of current row or upper half as indicated by `here` or `up` respectively.
 
 For example, in the following `Parameters`
 
@@ -61,7 +61,7 @@ The value for each key is
 - Key1: 3, given by `Config3`
 - Key2: 3, as it is value of `Key1` in the entire table
 - Key3: 2, as it is value of `Key1` defined in the current row
-- Key4: 1, as it is value of `Key2` defined in the upper row, which is in turn value of `Key1` defined in the table *containing the rows before `Config2`*, which is where `here(Key1)` originated.
+- Key4: 3, as it is value of `Key2` defined in the upper row, which is in turn value of `Key1` defined in the table, which should be 3 as overriden by `Config3`.
 
 If one config layer does not refer environment at all, `alterMap` and `alterPartial` can be used to avoid create a redundant `Config` object, as they accept `Map` and `PartialFunction` as their parameter.
 

--- a/cde/src/chipsalliance/rocketchip/config.scala
+++ b/cde/src/chipsalliance/rocketchip/config.scala
@@ -47,10 +47,7 @@ object config {
     final def lift[T](pname: Field[T]): Option[T] = find(pname)
 
     // All queries start here
-    protected[this] def find[T](pname: Field[T]): Option[T]
-
-    // Internal find call should have site information passed along
-    protected[config] def find[T](pname: Field[T], site: View): Option[T] = find(pname)
+    protected[config] def find[T](pname: Field[T]): Option[T]
   }
 
   /** Parameters are chain-able views, which can be strung together like a linked list.
@@ -115,8 +112,7 @@ object config {
       up:    View,
       pname: Field[T]
     ): Option[T]
-
-    protected[this] def find[T](pname: Field[T]): Option[T] =
+    protected[config] def find[T](pname: Field[T]): Option[T] =
       chain(this, this, new TerminalView, pname)
 
     // x orElse y: settings in 'x' overrule settings in 'y'
@@ -172,23 +168,19 @@ object config {
     def find[T](pname: Field[T]): Option[T] = pname.default
   }
 
-  private class ChainView(head: Parameters, up: View) extends View {
-    // If find is called in lookup table directly --- new site env
-    def find[T](pname: Field[T]) = head.chain(this, this, up, pname)
-
-    // If find is called in chain --- use site passed along
-    override def find[T](pname: Field[T], site: View) = head.chain(site, this, up, pname)
+  private class ChainView(head: Parameters, site: View, up: View) extends View {
+    def find[T](pname: Field[T]) = head.chain(site, this, up, pname)
   }
 
   private class ChainParameters(x: Parameters, y: Parameters) extends Parameters {
     def chain[T](site: View, here: View, up: View, pname: Field[T]) = {
-      x.chain(site, here, new ChainView(y, up), pname)
+      x.chain(site, here, new ChainView(y, site, up), pname)
     }
   }
 
   private class EmptyParameters extends Parameters {
     def chain[T](site: View, here: View, up: View, pname: Field[T]) =
-      up.find(pname, site)
+      up.find(pname)
   }
 
   private class PartialParameters(
@@ -202,7 +194,7 @@ object config {
     ) = {
       val g = f(site, here, up)
       if (g.isDefinedAt(pname)) Some(g.apply(pname).asInstanceOf[T])
-      else up.find(pname, site)
+      else up.find(pname)
     }
   }
 
@@ -214,7 +206,7 @@ object config {
       pname: Field[T]
     ) = {
       val g = map.get(pname)
-      if (g.isDefined) Some(g.get.asInstanceOf[T]) else up.find(pname, site)
+      if (g.isDefined) Some(g.get.asInstanceOf[T]) else up.find(pname)
     }
   }
 }

--- a/cde/tests/src/SanityTest.scala
+++ b/cde/tests/src/SanityTest.scala
@@ -79,13 +79,14 @@ object SanityTest extends TestSuite {
         C3.orElse(C2).orElse(C1)(MyKey2) ==> 2
       }
 
-      test("Each site/here/up query has its own environment") {
+      test("site() is always site()") {
         val C123 = C1.alter(C2).alter(C3)
 
         C123(MyKey1) ==> C3(MyKey1)
         // C123(MyKey4) ==> C2(up(MyKey2))
-        // C2(up(MyKey2)) then evaluates C1(site(MyKey1)) in environment C1
-        C123(MyKey4) ==> C1(MyKey1)
+        // C2(up(MyKey2)) then evaluates C1(site(MyKey1))
+        // site here still refers to C123 as query begins
+        C123(MyKey4) ==> C123(MyKey1)
       }
     }
   }


### PR DESCRIPTION
Through I would argue that in the `up` query the config chain should behave like as if overrides down the chain did not exist, unfortunately it breaks existing code (e.g. chipsalliance/rocket-chip#3014). Moreover, old behavior can make sense as `site` always refers to the entire `site` no matter what. So reverting back seems to be the way to go.

- reverts commit aa49948fe412840a0786a70df3dedf18ef002479 to avoid breakage in existing code
- update testcases to match old behavior
- update README.md to clarify how `site` should behave in a nested query